### PR TITLE
Update cpr to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ember-cli": "^1.13.0"
   },
   "dependencies": {
+    "cpr": "1.0.0",
     "debug": "^2.2.0",
     "exists-sync": "0.0.3",
     "findup-sync": "^0.3.0",


### PR DESCRIPTION
Prior to 1.0.0, there was an issue with `copy(src, dest, {overwrite:
true})` where it would delete files from the destination instead of
merging