### PR TITLE
Fix ember-data canary dependency

### DIFF
--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -85,7 +85,8 @@ function installPristineApp(appName) {
     .catch(handleResult)
     .then(function() {
       chdir(path.join(temp.pristinePath, appName));
-    });
+    })
+    .then(addEmberDataCanaryToDependencies(appName));
 
   // If we installed a fresh node_modules or bower_components directory,
   // grab those as pristine copies we can use in future runs.
@@ -97,7 +98,6 @@ function installPristineApp(appName) {
       .then(function() {
         debug("installed ember-disable-prototype-extension");
       })
-      .then(addEmberDataCanaryToDependencies(appName))
       .then(function() {
         return exec('npm install');
       })


### PR DESCRIPTION
Previously the ember-data dependency was *only* added to the
`package.json` file when *no node_module cache existed*. This caused
ember-data canary to be installed and correctly required for the *first*
fixture in tests. Subsequent tests would use whatever ember-data version
was specified by `ember new` as the requirement, which would then cause
a conflict, since the installed version was canary. This is fixed by
modifying the `package.json` for every pristine app generated, instead
of only the first one