### PR TITLE
Allow specifying a custom fixtures path

### DIFF
--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -16,7 +16,7 @@ function AddonTestApp() {
 // exist already, it will create it and put it into the `pristine`
 // directory, then put a copy into `under-test`. Subsequent calls
 // to `createApp()` will use the pristine app as a cache.
-AddonTestApp.prototype.create = function(appName) {
+AddonTestApp.prototype.create = function(appName, options) {
   this.appName = appName;
 
   var app = this;
@@ -24,7 +24,7 @@ AddonTestApp.prototype.create = function(appName) {
   return pristine.cloneApp(appName)
     .then(function(appPath) {
       app.path = appPath;
-      return copyFixtureFiles(appName, appPath);
+      return copyFixtureFiles(appName, appPath, options.fixturesPath);
     })
     .then(function() {
       return app;
@@ -82,8 +82,8 @@ AddonTestApp.prototype.stopServer = function() {
   return RSVP.resolve();
 };
 
-function copyFixtureFiles(appName, destDir) {
-  var fixturesPath = findup('tests/fixtures');
+function copyFixtureFiles(appName, destDir, fixturesPath) {
+  fixturesPath = findup(fixturesPath || 'tests/fixtures');
   var sourceDir = path.join(fixturesPath, appName);
 
   debug("copying fixtures; from=%s; to=%s", sourceDir, destDir);


### PR DESCRIPTION
This allows separating the normal Ember tests from the node acceptance tests.

```js
app = new AddonTestApp();
return app.create('test-app', { fixturesPath: 'node-tests/fixtures' })
```