### PR TITLE
Remove ember-data from bower when present

### DIFF
--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -18,6 +18,7 @@ function AddonTestApp() {
 // to `createApp()` will use the pristine app as a cache.
 AddonTestApp.prototype.create = function(appName, options) {
   this.appName = appName;
+  options = options || {};
 
   var app = this;
 

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -108,7 +108,8 @@ function installPristineApp(appName) {
       .then(symlinkAddon);
   }
 
-  promise = promise.then(addEmberCanaryToBowerJSON(appName));
+  promise = promise.then(addEmberCanaryToBowerJSON(appName))
+                   .then(removeEmberDataFromBowerJSON(appName));
 
   if (!hasBowerComponents) {
     promise = promise.then(function() {
@@ -169,6 +170,17 @@ function addEmberCanaryToBowerJSON(appName) {
     };
 
     bowerJSON.dependencies['ember'] = 'canary';
+
+    fs.writeJsonSync(bowerJSONPath, bowerJSON);
+  };
+}
+
+function removeEmberDataFromBowerJSON(appName) {
+  return function() {
+    var bowerJSONPath = path.join(temp.pristinePath, appName, 'bower.json');
+    var bowerJSON = fs.readJsonSync(bowerJSONPath);
+
+    delete bowerJSON.dependencies['ember-data'];
 
     fs.writeJsonSync(bowerJSONPath, bowerJSON);
   };


### PR DESCRIPTION
Since we include ember-data canary in the package.json, if the addon is under test is using `ember-cli` prior to 2.4.0 (when ember-data became an addon)

Also fixes an issue where `AddonTestApp.create` explodes when options is
not passed in