### PR TITLE
Run addon's default blueprint

### DIFF
--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -7,7 +7,6 @@ var chdir = require('./chdir');
 var fs = require('fs-extra');
 var findup = require('findup-sync');
 var existsSync       = fs.existsSync;
-var runCommand       = require('./run-command');
 var RSVP             = require('rsvp');
 var Promise = RSVP.Promise;
 var exec             = RSVP.denodeify(require('child_process').exec);
@@ -67,11 +66,11 @@ function installPristineApp(appName) {
     debug("no node_modules or bower_components");
   // bower_components but no node_modules
   } else if (!hasNodeModules && hasBowerComponents) {
-    debug("no node_modules but existng bower_components");
+    debug("no node_modules but existing bower_components");
     extraOptions = ['--skip-bower'];
   // node_modules but no bower_components
   } else if (hasNodeModules && !hasBowerComponents) {
-    debug("no bower_components but existng node_modules");
+    debug("no bower_components but existing node_modules");
     extraOptions = ['--skip-npm'];
   // Everything is already there
   } else {
@@ -104,12 +103,12 @@ function installPristineApp(appName) {
       .then(function() {
         debug('installed ember-data canary');
       })
-      .then(movePristineNodeModules(appName))
-      .then(symlinkAddon);
+      .then(symlinkAddon(appName));
   }
 
   promise = promise.then(addEmberCanaryToBowerJSON(appName))
-                   .then(removeEmberDataFromBowerJSON(appName));
+                   .then(removeEmberDataFromBowerJSON(appName))
+                   .then(addAddonUnderTestToDependencies(appName));
 
   if (!hasBowerComponents) {
     promise = promise.then(function() {
@@ -117,12 +116,21 @@ function installPristineApp(appName) {
     })
     .then(function() {
       debug("installed ember#canary");
-    })
-    .then(movePristineBowerComponents(appName));
+    });
   }
 
-  return promise.then(addAddonUnderTestToDependencies(appName))
-    .then(linkDependencies(appName));
+  // at this point we have all deps available, so we can run ember-cli
+  promise = promise.then(runAddonGenerator);
+
+  if (!hasNodeModules) {
+    promise = promise.then(movePristineNodeModules(appName));
+  }
+
+  if (!hasBowerComponents) {
+    promise = promise.then(movePristineBowerComponents(appName));
+  }
+
+  return promise.then(linkDependencies(appName));
 }
 
 function hasPristineNodeModules() {
@@ -186,24 +194,26 @@ function removeEmberDataFromBowerJSON(appName) {
   };
 }
 
-function symlinkAddon() {
-  var pkg = findAddonPackageJSON();
-  var addonPath = findAddonPath();
-  var addonSymlinkPath = path.join(temp.pristineNodeModulesPath, pkg.name);
+function symlinkAddon(appName) {
+  return function() {
+    var pkg = findAddonPackageJSON();
+    var addonPath = findAddonPath();
+    var addonSymlinkPath = path.join(temp.pristinePath, appName, 'node_modules', pkg.name);
 
-  debug("symlinking %s", pkg.name);
+    debug("symlinking %s", pkg.name);
 
-  if (existsSync(addonSymlinkPath)) {
-    var stats = fs.lstatSync(addonSymlinkPath);
-    if (stats.isSymbolicLink()) {
-      debug("%s is already symlinked", pkg.name);
-      return;
+    if (existsSync(addonSymlinkPath)) {
+      var stats = fs.lstatSync(addonSymlinkPath);
+      if (stats.isSymbolicLink()) {
+        debug("%s is already symlinked", pkg.name);
+        return;
+      }
+
+      fs.removeSync(addonSymlinkPath);
     }
 
-    fs.removeSync(addonSymlinkPath);
-  }
-
-  symlinkDirectory(addonPath, addonSymlinkPath);
+    symlinkDirectory(addonPath, addonSymlinkPath);
+  };
 }
 
 function addEmberDataCanaryToDependencies(appName) {
@@ -236,6 +246,27 @@ function addAddonUnderTestToDependencies(appName) {
 
     fs.writeJsonSync('package.json', packageJSON);
   };
+}
+
+function runAddonGenerator() {
+  var pkg = findAddonPackageJSON();
+  var emberCLIPath = findup('node_modules/ember-cli', {
+    cwd: __dirname
+  });
+
+  debug('running %s generator', pkg.name);
+
+  var blueprintName = pkg.name;
+  var emberAddon = pkg['ember-addon'];
+
+  if (emberAddon && emberAddon.defaultBlueprint) {
+    blueprintName = emberAddon.defaultBlueprint;
+  }
+
+  var args = [path.join(emberCLIPath, 'bin', 'ember'), 'generate', blueprintName];
+
+  return runCommand.apply(undefined, args)
+    .catch(function(){});
 }
 
 function findAddonPath() {


### PR DESCRIPTION
Rationale: when adding an addon to an app through `ember install ...`, the addon's default blueprint is executed, to add additional files to the app or (most often) add additional bower assets. Here the addon is just added to `package.json` without that generator step, leading to broken builds when required assets are missing.

This PR adds an additional `ember generate ...` step to fix that.