### PR TITLE
Allow for nested addons

### DIFF
--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -249,13 +249,18 @@ function findAddonPackageJSON() {
 }
 
 function findAddonPackageJSONPath() {
-  var packageJSONPath = findup('package.json', {
-    cwd: path.join(__dirname, '../../..')
-  });
+  var lastPath;
+  var foundPath;
 
-  debug('found addon package.json; path=%s', packageJSONPath);
+  while (foundPath = findup('package.json', {
+    cwd: lastPath ? path.join(lastPath, '../..') : path.join(__dirname, '../../..')
+  })) {
+    lastPath = foundPath;
+  }
 
-  return packageJSONPath;
+  debug('found addon package.json; path=%s', lastPath);
+
+  return lastPath;
 }
 
 function linkDependencies(appName) {


### PR DESCRIPTION
Given you have a dependency tree like this:

    addonUnderTest -> addonInTheMiddle -> ember-cli-addon-tests

where `addonInTheMiddle` brings in the dependency to `ember-cli-addon-tests`. When running the temporary generated app the `addonInTheMiddle` addon is installed into this app, and not `addonUnderTest`.

This is because `findAddonPackageJSONPath` looks for the *first* folder with a `package.json` up the `node_modules` tree, which is `addonInTheMiddle` in this case. The proposed change traverses up the folder tree to find the *last* folder with a `package.json`, so `addonUnderTest` in this case.

I am in the middle of pulling up an addon that supports other addons testing for Fastboot compatibility, so this is needed for my case, as the dependency tree looks like the above.

 