### PR TITLE
Allow for specifying the versions of ember and ember-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ application as the first argument.
 app.create('my-app');
 ```
 
+#### Options
+
+You can customize the app by supplying an options hash:
+
+```js
+// returns a promise
+app.create('my-app', {
+  emberVersion: 'release'
+});
+```
+
+The following options exist: 
+ 
+| option           | description                                                                             | defaults to         |
+|------------------|-----------------------------------------------------------------------------------------|---------------------|
+| emberVersion     | Set the ember version the app should be created with, as you would in your `bower.json` | canary              |
+| emberDataVersion | Set the version of ember-data, as you would in your `package.json`                      | emberjs/data#master |
+| fixturesPath     | The path to look for your fixture files (see below)                                     | test/fixtures       |
+
+
 #### Fixtures
 
 You will probably want to add files to the Ember application that you

--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -22,7 +22,7 @@ AddonTestApp.prototype.create = function(appName, options) {
 
   var app = this;
 
-  return pristine.cloneApp(appName)
+  return pristine.cloneApp(appName, options)
     .then(function(appPath) {
       app.path = appPath;
       return copyFixtureFiles(appName, appPath, options.fixturesPath);

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -14,7 +14,7 @@ var moveDirectory    = require('./move-directory');
 var symlinkDirectory = require('./symlink-directory');
 var runCommand       = require('./run-command');
 
-function cloneApp(appName) {
+function cloneApp(appName, options) {
   var tempDir = temp.ensureCreated();
   var previousCwd = process.cwd();
 
@@ -32,7 +32,7 @@ function cloneApp(appName) {
 
   // If a pristine version of the app doesn't exist, create it.
   if (!fs.existsSync(pristineAppPath)) {
-    return installPristineApp(appName)
+    return installPristineApp(appName, options)
       .then(function() {
         copyUnderTestApp(pristineAppPath, underTestAppPath);
       })
@@ -52,10 +52,12 @@ module.exports = {
   cloneApp: cloneApp
 };
 
-function installPristineApp(appName) {
+function installPristineApp(appName, options) {
   var hasNodeModules = hasPristineNodeModules();
   var hasBowerComponents = hasPristineBowerComponents();
   var extraOptions = [];
+  var emberVersion = options.emberVersion || 'canary';
+  var emberDataVersion = options.emberDataVersion || 'emberjs/data#master';
 
   // First, determine if we can skip installing npm packages
   // or Bower components if we have a pristine set of dependencies
@@ -85,7 +87,7 @@ function installPristineApp(appName) {
     .then(function() {
       chdir(path.join(temp.pristinePath, appName));
     })
-    .then(addEmberDataCanaryToDependencies(appName));
+    .then(addEmberDataToDependencies(appName, emberDataVersion));
 
   // If we installed a fresh node_modules or bower_components directory,
   // grab those as pristine copies we can use in future runs.
@@ -101,12 +103,12 @@ function installPristineApp(appName) {
         return exec('npm install');
       })
       .then(function() {
-        debug('installed ember-data canary');
+        debug('installed ember-data ' + emberDataVersion);
       })
       .then(symlinkAddon(appName));
   }
 
-  promise = promise.then(addEmberCanaryToBowerJSON(appName))
+  promise = promise.then(addEmberToBowerJSON(appName, emberVersion))
                    .then(removeEmberDataFromBowerJSON(appName))
                    .then(addAddonUnderTestToDependencies(appName));
 
@@ -115,7 +117,7 @@ function installPristineApp(appName) {
       return exec('bower install');
     })
     .then(function() {
-      debug("installed ember#canary");
+      debug('installed ember ' + emberVersion);
     });
   }
 
@@ -168,16 +170,16 @@ function copyUnderTestApp(pristineAppPath, underTestAppPath) {
   chdir(underTestAppPath);
 }
 
-function addEmberCanaryToBowerJSON(appName) {
+function addEmberToBowerJSON(appName, version) {
   return function() {
     var bowerJSONPath = path.join(temp.pristinePath, appName, 'bower.json');
     var bowerJSON = fs.readJsonSync(bowerJSONPath);
 
     bowerJSON.resolutions = {
-      "ember": "canary"
+      "ember": version
     };
 
-    bowerJSON.dependencies['ember'] = 'canary';
+    bowerJSON.dependencies['ember'] = version;
 
     fs.writeJsonSync(bowerJSONPath, bowerJSON);
   };
@@ -216,16 +218,16 @@ function symlinkAddon(appName) {
   };
 }
 
-function addEmberDataCanaryToDependencies(appName) {
+function addEmberDataToDependencies(appName, version) {
   return function() {
     var pkg = findAddonPackageJSON();
     var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
 
-    debug('installing ember-data canary');
+    debug('installing ember-data ' + version);
 
     var packageJSON = fs.readJsonSync(packageJSONPath);
 
-    packageJSON.devDependencies['ember-data'] = 'emberjs/data#master';
+    packageJSON.devDependencies['ember-data'] = version;
 
     fs.writeJsonSync('package.json', packageJSON);
   };


### PR DESCRIPTION
The versions of ember and ember-data have been hardcoded (to `canary`) so far. This is not always desirable. Especially the inclusion of Glimmer2 into canary led to some failing Fastboot tests in CI for one of my addons. So running my tests with the `release` version would be more useful (as `canary` is also allowed to fail in `ember-try`tests).

This change extends the option hash already present for `AddonTestApp` to add the `emberVersion`and `emberDataVersion` options that allow you to specify the versions to be used. When omited the defaults are the same as before (`canary`), so this should not be a breaking change.

**Note**: this PR does include the commit from #13 as some of the same lines of code are affected, otherwise there would be larger merge conflicts. So #13 should be merged first.