### PR TITLE
use the same debug everywhere

### DIFF
--- a/lib/utilities/symlink-directory.js
+++ b/lib/utilities/symlink-directory.js
@@ -1,5 +1,5 @@
 var symlinkOrCopySync = require('symlink-or-copy').sync;
-var debug             = require('debug')('fastboot-test');
+var debug             = require('./debug');
 var path              = require('path');
 
 module.exports = function (from, to) {


### PR DESCRIPTION
It looks like it was a typo. So the symlink statements show up with the rest in the debugger.