### PR TITLE
travis needs bower installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ node_js:
 cache:
   directories:
     - node_modules
+
+before_install:
+  - npm config set spin false
+  - npm install -g bower
+  - bower --version


### PR DESCRIPTION
This is one of the reasons travis is not passing. (was only broken in node 0.12 and node 4, I guess node 6 containers on travis already have bower?)