### PR TITLE
Extract App class from AddonTestApp

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var App = require('./models/app');
 var AddonTestApp = require('./models/addon-test-app');
 
 module.exports = {
+  App: App,
   AddonTestApp: AddonTestApp
 };

--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -1,16 +1,18 @@
 var fs         = require('fs-extra');
 var path       = require('path');
 var findup     = require('findup-sync');
-var startServer = require('../commands/start-server');
-var chdir      = require('../utilities/chdir');
+var util       = require('util');
+var App        = require('./app');
 var debug      = require('../utilities/debug');
-var runCommand = require('../utilities/run-command');
 var pristine   = require('../utilities/pristine');
 var RSVP = require('rsvp');
 var copy = RSVP.denodeify(require('cpr'));
 
 function AddonTestApp() {
+  App.call(this);
 }
+
+util.inherits(AddonTestApp, App);
 
 // Public API for putting an app under test. If the app doesn't
 // exist already, it will create it and put it into the `pristine`
@@ -32,55 +34,11 @@ AddonTestApp.prototype.create = function(appName, options) {
     });
 };
 
-AddonTestApp.prototype.run = function() {
-  var previousCwd = process.cwd();
-  chdir(this.path);
-
-  return runCommand.apply(null, arguments)
-    .finally(function() {
-      chdir(previousCwd);
-    });
-};
-
-AddonTestApp.prototype.runEmberCommand = function() {
-  var cliPath = path.join(this.path, 'node_modules', 'ember-cli', 'bin', 'ember');
-  var args = Array.prototype.slice.apply(arguments);
-
-  return this.run.apply(this, [cliPath].concat(args));
-};
-
-AddonTestApp.prototype.filePath = function(filePath) {
-  return path.join(this.path, filePath);
-};
-
 AddonTestApp.prototype.editPackageJSON = function(cb) {
   var packageJSONPath = path.join(this.path, 'package.json');
   var pkg = fs.readJsonSync(packageJSONPath);
   cb(pkg);
   fs.writeJsonSync(packageJSONPath, pkg);
-};
-
-AddonTestApp.prototype.startServer = function(options) {
-  var app = this;
-  var previousCwd = process.cwd();
-  process.chdir(app.path);
-
-  return startServer(options)
-    .then(function(server) {
-      app.server = server;
-      process.chdir(previousCwd);
-    });
-};
-
-AddonTestApp.prototype.stopServer = function() {
-  if (!this.server) {
-    throw new Error("You must call `startServer()` before calling `stopServer()`.");
-  }
-
-  this.server.kill('SIGINT');
-  this.server = null;
-
-  return RSVP.resolve();
 };
 
 function copyFixtureFiles(appName, destDir, fixturesPath) {

--- a/lib/models/app.js
+++ b/lib/models/app.js
@@ -1,0 +1,55 @@
+var path       = require('path');
+var startServer = require('../commands/start-server');
+var chdir      = require('../utilities/chdir');
+var runCommand = require('../utilities/run-command');
+var RSVP = require('rsvp');
+
+function App(path) {
+  this.path = path;
+}
+
+App.prototype.run = function() {
+  var previousCwd = process.cwd();
+  chdir(this.path);
+
+  return runCommand.apply(null, arguments)
+    .finally(function() {
+      chdir(previousCwd);
+    });
+};
+
+App.prototype.runEmberCommand = function() {
+  var cliPath = path.join(this.path, 'node_modules', 'ember-cli', 'bin', 'ember');
+  var args = Array.prototype.slice.apply(arguments);
+
+  return this.run.apply(this, [cliPath].concat(args));
+};
+
+App.prototype.filePath = function(filePath) {
+  return path.join(this.path, filePath);
+};
+
+App.prototype.startServer = function(options) {
+  var app = this;
+  var previousCwd = process.cwd();
+  process.chdir(app.path);
+
+  return startServer(options)
+    .then(function(server) {
+      app.server = server;
+      process.chdir(previousCwd);
+    });
+};
+
+App.prototype.stopServer = function() {
+  if (!this.server) {
+    throw new Error("You must call `startServer()` before calling `stopServer()`.");
+  }
+
+  this.server.kill('SIGINT');
+  this.server = null;
+
+  return RSVP.resolve();
+};
+
+module.exports = App;


### PR DESCRIPTION
This allows us to test our real app using the same nice API as we can use for addons:

```js
  before(function() {
    app = new App(path.normalize(`${__dirname}/..`));

    return app.startServer({
      command: 'fastboot'
    });
  });
```

/cc @simonihmig 