### PR TITLE
Remove ember-source explicitly if present

### DIFF
--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,8 @@ function installPristineApp(appName, options) {
     .then(function() {
       chdir(path.join(temp.pristinePath, appName));
     })
-    .then(addEmberDataToDependencies(appName, emberDataVersion));
+    .then(addEmberDataToDependencies(appName, emberDataVersion))
+    .then(removeEmberSourceFromDependencies(appName, emberVersion));
 
   // If we installed a fresh node_modules or bower_components directory,
   // grab those as pristine copies we can use in future runs.
@@ -243,6 +244,23 @@ function addEmberDataToDependencies(appName, version) {
     packageJSON.devDependencies['ember-data'] = version;
 
     fs.writeJsonSync('package.json', packageJSON);
+  };
+}
+
+function removeEmberSourceFromDependencies(appName, version) {
+  return function() {
+    var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
+
+    var packageJSON = fs.readJsonSync(packageJSONPath);
+
+    if (version === 'canary' && packageJSON.devDependencies.hasOwnProperty('ember-source')) {
+      // ember-source does not support canary builds, therefore we will remove this entry and
+      // use ember from bower
+      debug('removing ember-source from NPM ');
+
+      delete packageJSON.devDependencies['ember-source'];
+      fs.writeJsonSync('package.json', packageJSON);
+    }
   };
 }
 

--- a/test/fixtures/my-addon/package.json
+++ b/test/fixtures/my-addon/package.json
@@ -31,6 +31,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-source": "2.11.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
With `ember-cli` 2.11.0+ the blueprint removes `ember` from bower.json and adds `ember-source` as NPM package. `ember-source` current doesn't support canary builds which is what this addon defaults to when installing ember version if none is provided. Therefore, explicitly remove `ember-source` to avoid confusion for now. At a later, we install `ember` as a bower component. This PR is to avoid confusion.

cc: @rwjblue
