### PR TITLE
fix app.run(npm) on windows

### DIFF
--- a/lib/utilities/run-command.js
+++ b/lib/utilities/run-command.js
@@ -1,12 +1,17 @@
 'use strict';
 
-var Promise        = require('rsvp').Promise;
+var RSVP           = require('rsvp');
+var Promise        = RSVP.Promise;
 var chalk          = require('chalk');
-var spawn          = require('child_process').spawn;
+var childProcess   = require('child_process');
+var spawn          = childProcess.spawn;
 var defaults       = require('lodash/object/defaults');
 var killCliProcess = require('./kill-cli-process');
 var debug          = require('./debug');
 var logOnFailure   = require('./log-on-failure');
+var exec           = RSVP.denodeify(childProcess.exec);
+
+var isWindows = process.platform === 'win32';
 
 module.exports = function run(/* command, args, options */) {
   var command = arguments[0];
@@ -18,6 +23,11 @@ module.exports = function run(/* command, args, options */) {
   }
 
   debug("running command=" + command + "; args=" + args + "; cwd=" + process.cwd());
+
+  if (isWindows && command === 'npm') {
+    return exec(command + ' ' + args.join(' '));
+  }
+
   options = defaults(options, {
 
     onOutput: function(string) {
@@ -37,7 +47,7 @@ module.exports = function run(/* command, args, options */) {
 
   return new Promise(function(resolve, reject) {
     var opts = {};
-    if (process.platform === 'win32') {
+    if (isWindows) {
       args = ['"' + command + '"'].concat(args);
       command = 'node';
       opts.windowsVerbatimArguments = true;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chai": "^3.5.0",
     "cross-env": "^3.1.4",
     "ember-cli": "^1.13.0",
+    "ember-cli-fastboot": "1.0.0-beta.15",
     "mocha": "^3.1.2",
     "request": "^2.75.0"
   },

--- a/test/acceptance/application-test.js
+++ b/test/acceptance/application-test.js
@@ -34,6 +34,11 @@ describe('Acceptance | application', function() {
         fixturesPath: 'tests'
       });
     }).then(function() {
+      app.editPackageJSON(function(pkg) {
+        pkg.devDependencies['ember-cli-fastboot'] = process.env.npm_package_devDependencies_ember_cli_fastboot;
+      });
+      return app.run('npm', 'install');
+    }).then(function() {
       return app.startServer();
     });
   });


### PR DESCRIPTION
Uses exec like [here](https://github.com/tomdale/ember-cli-addon-tests/blob/664e173a106abec55dae0ac18435ed4defb99c31/lib/utilities/pristine.js#L106) which has been working on Windows fine.