### PR TITLE
increase timeout on windows

### DIFF
--- a/test/acceptance/application-test.js
+++ b/test/acceptance/application-test.js
@@ -18,7 +18,7 @@ function promoteHtmlbars() {
 }
 
 describe('Acceptance | application', function() {
-  this.timeout(300000);
+  this.timeout(process.platform === 'win32' ? 500000 : 300000);
 
   var previousCwd;
   var app;


### PR DESCRIPTION
after the new `npm install` added in the acceptance test, the test time increased a few mins.