### PR TITLE
try to fix appveyor cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,8 @@ test_script:
   - bower --version
   - npm test
 
-# http://help.appveyor.com/discussions/questions/1310-delete-cache
 cache:
-  - node_modules -> package.json
+  - '%APPDATA%\npm-cache'
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
Trying to fix the intermittent issue in appveyor
```
    "EPERM: operation not permitted, rename 'C:\\Users\\appveyor\\AppData\\Roaming\\npm-cache\\rsvp\\3.2.1\\package.tgz.3343431550' -> 'C:\\Users\\appveyor\\AppData\\Roaming\\npm-cache\\rsvp\\3.2.1\\package.tgz'\r\n"
```