### PR TITLE
Force ember-cli path to be one of addon when running ember commands.

### DIFF
--- a/lib/commands/start-server.js
+++ b/lib/commands/start-server.js
@@ -5,6 +5,7 @@ var path     = require('path');
 var debug    = require('../utilities/debug');
 var runEmber = require('../utilities/run-ember');
 var _        = require('lodash');
+var temp     = require('../utilities/temp');
 
 module.exports = function runServer(options) {
   return new RSVP.Promise(function(resolve, reject) {
@@ -37,7 +38,7 @@ module.exports = function runServer(options) {
 
     debug('starting server; command=%s; port=%s', options.command, options.port);
 
-    runEmber(options.command, args)
+    runEmber(options.command, args, temp.pristineNodeModulesPath)
       .then(function() {
         throw new Error('The server should not have exited successfully.');
       })

--- a/lib/utilities/run-ember.js
+++ b/lib/utilities/run-ember.js
@@ -4,9 +4,9 @@ var path = require('path');
 var findup = require('findup-sync');
 var runCommand = require('./run-command');
 
-module.exports = function(command, options) {
+module.exports = function(command, options, dirPath) {
   var emberCLIPath = findup('node_modules/ember-cli', {
-    cwd: __dirname
+    cwd: dirPath || __dirname
   });
 
   var args = [path.join(emberCLIPath, 'bin', 'ember'), command].concat(options);


### PR DESCRIPTION
By default `runEmber` method was using `ember-cli` of `ember-cli-addon-tests` (which is pretty old version right now) when it should be using of the addon that is writing tests. The reason being the addon might be using features of ember-cli and may want to test. We can't default to always using the app's version since when using `ember new <appName>`, the ember-cli node module isn't copied to pristine yet. Hence keeping it as opt in feature.

cc: @rwjblue @tomdale @simonihmig 