### PR TITLE
protect against an empty bower folder

### DIFF
--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -133,7 +133,9 @@ function installPristineApp(appName, options) {
     promise = promise.then(movePristineNodeModules(appName));
   }
 
-  if (!hasBowerComponents) {
+  // make sure there are now bower components
+  // (new projects don't have bower components and won't have this folder)
+  if (!hasBowerComponents && hasPristineBowerComponents()) {
     promise = promise.then(movePristineBowerComponents(appName));
   }
 

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -328,7 +328,10 @@ function linkDependencies(appName) {
     var bowerComponentsAppPath = path.join(temp.pristinePath, appName, 'bower_components');
 
     symlinkDirectory(temp.pristineNodeModulesPath, nodeModulesAppPath);
-    symlinkDirectory(temp.pristineBowerComponentsPath, bowerComponentsAppPath);
+    // might not have a bower components folder
+    if (hasPristineBowerComponents()) {
+      symlinkDirectory(temp.pristineBowerComponentsPath, bowerComponentsAppPath);
+    }
   };
 }
 


### PR DESCRIPTION
prevent this error:

```
Error: ENOENT: no such file or directory, rename 'C:\Users\kelly\AppData\Local\Temp\d-117120-15440-1saglv3.hk9g722o6r\pristine\dummy\bower_components' -> 'C:\Users\kelly\AppData\Local\Temp\d-117120-15440-1saglv3.hk9g722o6r\pristine\bower_components'
      at fs.renameSync (fs.js:742:18)
      at moveDirectory (node_modules\ember-cli-addon-tests\lib\utilities\move-directory.js:14:5)
      at node_modules\ember-cli-addon-tests\lib\utilities\pristine.js:163:5
      at tryCatch (node_modules\rsvp\dist\rsvp.js:538:12)
      at invokeCallback (node_modules\rsvp\dist\rsvp.js:553:13)
      at publish (node_modules\rsvp\dist\rsvp.js:521:7)
      at flush (node_modules\rsvp\dist\rsvp.js:2373:5)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```