### PR TITLE
treat bower like npm in windows

### DIFF
--- a/lib/utilities/run-command.js
+++ b/lib/utilities/run-command.js
@@ -24,7 +24,7 @@ module.exports = function run(/* command, args, options */) {
 
   debug("running command=" + command + "; args=" + args + "; cwd=" + process.cwd());
 
-  if (isWindows && command === 'npm') {
+  if (isWindows && (command === 'npm' || command === 'bower')) {
     return exec(command + ' ' + args.join(' '));
   }
 


### PR DESCRIPTION
prevent this error:

```
Error: ENOENT: no such file or directory, rename 'C:\Users\kelly\AppData\Local\Temp\d-117120-15440-1saglv3.hk9g722o6r\pristine\dummy\bower_components' -> 'C:\Users\kelly\AppData\Local\Temp\d-117120-15440-1saglv3.hk9g722o6r\pristine\bower_components'
      at fs.renameSync (fs.js:742:18)
      at moveDirectory (node_modules\ember-cli-addon-tests\lib\utilities\move-directory.js:14:5)
      at node_modules\ember-cli-addon-tests\lib\utilities\pristine.js:163:5
      at tryCatch (node_modules\rsvp\dist\rsvp.js:538:12)
      at invokeCallback (node_modules\rsvp\dist\rsvp.js:553:13)
      at publish (node_modules\rsvp\dist\rsvp.js:521:7)
      at flush (node_modules\rsvp\dist\rsvp.js:2373:5)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```

not sure yet why appveyor was still working, but this fixes me locally. something for me to look out for in the future. 