### PR TITLE
Support using absolute fixture paths

### DIFF
--- a/lib/utilities/copy-fixture-files.js
+++ b/lib/utilities/copy-fixture-files.js
@@ -4,7 +4,7 @@ var debug = require('../utilities/debug');
 var RSVP = require('rsvp');
 var copy = RSVP.denodeify(require('cpr'));
 
-function copyFixtureFiles(appName, destDir, fixturesPath) {
+function findFixturesPath(fixturesPath) {
   fixturesPath = findup(fixturesPath || 'test/fixtures');
 
   if (!fixturesPath) {
@@ -13,6 +13,14 @@ function copyFixtureFiles(appName, destDir, fixturesPath) {
 
   if (!fixturesPath) {
     throw new Error("Could not find fixtures directory. Make sure you have a fixtures directory in your `test/` directory. You may encounter this issue if you have npm linked this package; copy it to your node_modules directory instead.");
+  }
+
+  return fixturesPath;
+}
+
+function copyFixtureFiles(appName, destDir, fixturesPath) {
+  if (!fixturesPath || !path.isAbsolute(fixturesPath)) {
+    fixturesPath = findFixturesPath(fixturesPath);
   }
 
   var sourceDir = path.join(fixturesPath, appName);


### PR DESCRIPTION
If an absolute path for fixtures is passed in the options, then we shouldn't attempt to find a different path. This makes it easier to figure out how to set `fixturesPath` as the current process is unintuitive that it is relative to the process' working directory.