### PR TITLE
Add noFixtures option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,14 @@ app.create('my-app', {
 });
 ```
 
-The following options exist: 
- 
+The following options exist:
+
 | option           | description                                                                             | defaults to         |
 |------------------|-----------------------------------------------------------------------------------------|---------------------|
 | emberVersion     | Set the ember version the app should be created with, as you would in your `bower.json` | canary              |
 | emberDataVersion | Set the version of ember-data, as you would in your `package.json`                      | emberjs/data#master |
 | fixturesPath     | The path to look for your fixture files (see below)                                     | test/fixtures       |
+| noFixtures       | Disables the use of fixture files                                                       | false               |
 
 
 #### Fixtures
@@ -129,6 +130,9 @@ application that you created.
 For example, if you call `app.create('my-app')`, the test helper will
 look for a file called `test/fixtures/my-app` in your addon's directory
 and will copy them to the test app, overwriting any files that exist.
+
+If you do not need fixture files in your test, you can disable them by
+specifying the `noFixtures` option.
 
 ### Editing App's `package.json`
 

--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -4,6 +4,7 @@ var util       = require('util');
 var App        = require('./app');
 var pristine   = require('../utilities/pristine');
 var copyFixtureFiles = require('../utilities/copy-fixture-files');
+var RSVP = require('rsvp');
 
 function AddonTestApp() {
   App.call(this);
@@ -24,7 +25,9 @@ AddonTestApp.prototype.create = function(appName, options) {
   return pristine.cloneApp(appName, options)
     .then(function(appPath) {
       app.path = appPath;
-      return copyFixtureFiles(appName, appPath, options.fixturesPath);
+      return options.noFixtures ?
+        RSVP.resolve() :
+        copyFixtureFiles(appName, appPath, options.fixturesPath);
     })
     .then(function() {
       return app;


### PR DESCRIPTION
Adds an option to disable automatic inclusion of fixtures if you don't need them. Currently, if you don't need fixtures, you have to set up an empty directory because an error is thrown if they're not found.