### PR TITLE
Bump dependencies to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     - node_modules
 
 before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm config set spin false
   - npm install -g bower
   - bower --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ init:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm i -g npm@^3
   - npm config set spin false
   - npm install -g bower
   - npm install

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "cpr": "^2.0.0",
     "debug": "^2.2.0",
     "exists-sync": "0.0.4",
-    "findup-sync": "^0.4.3",
-    "fs-extra": "^2.0.0",
+    "findup-sync": "^1.0.0",
+    "fs-extra": "^3.0.0",
     "fs-promise": "^2.0.0",
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.1",
@@ -35,9 +35,9 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "cross-env": "^3.1.4",
-    "ember-cli": "~2.9.0",
-    "ember-cli-fastboot": "1.0.0-beta.15",
+    "cross-env": "^4.0.0",
+    "ember-cli": "~2.12.0",
+    "ember-cli-fastboot": "1.0.0-beta.18",
     "mocha": "^3.1.2",
     "request": "^2.75.0"
   },


### PR DESCRIPTION
It appears that semver drift is the culprit of tests failing. I _think_ the root cause was something in the ember-cli 2.9.x series, but do not know exactly what.

Fixes https://github.com/tomdale/ember-cli-addon-tests/issues/87