### PR TITLE
Refactor pristine + fix ember-cli@2.13

### DIFF
--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -22,7 +22,7 @@ AddonTestApp.prototype.create = function(appName, options) {
 
   var app = this;
 
-  return pristine.cloneApp(appName, options)
+  return pristine.createApp(appName, options)
     .then(function(appPath) {
       app.path = appPath;
       return options.noFixtures ?

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -94,11 +94,13 @@ function installPristineApp(appName, options) {
     emberDataVersion: options.emberDataVersion || 'emberjs/data#master'
   };
 
-  promise = chainNodeModulesSetup(promise, setupOptions);
-
-  if (usesBower) {
-    promise = chainBowerSetup(promise, setupOptions);
-  }
+  promise = promise
+    .then(() => nodeModulesSetup(setupOptions))
+    .then(() => {
+      if (usesBower) {
+        return bowerSetup(setupOptions);
+      }
+    });
 
   // All dependencies should be installed, so symlink them into the app and
   // run the addon's blueprint to finish the app creation.
@@ -125,13 +127,16 @@ function generateArgsForEmberNew(skipNpm, skipBower) {
   return extraOptions.concat(runCommandOptions);
 }
 
-function chainNodeModulesSetup(promise, options) {
-  let { appName, emberDataVersion, emberVersion, hasNodeModules } = options;
+function nodeModulesSetup(options) {
+  let appName = options.appName;
+  let emberVersion = options.emberVersion;
+  let emberDataVersion = options.emberDataVersion;
+  let hasNodeModules = options.hasNodeModules;
 
   // Modifies the package.json to include correct versions of dependencies
-  promise = promise
+  let promise = Promise.resolve()
     .then(() => addEmberDataToDependencies(appName, emberDataVersion))
-    .then(() => removeEmberSourceFromDependencies(appName, emberVersion));
+    .then(() => updateEmberSource(appName, emberVersion));
 
   if (!hasNodeModules) {
     promise = promise
@@ -151,10 +156,12 @@ function chainNodeModulesSetup(promise, options) {
   return promise.then(() => addAddonUnderTestToDependencies(appName));
 }
 
-function chainBowerSetup(promise, options) {
-  let { appName, emberVersion, hasBowerComponents } = options;
+function bowerSetup(options) {
+  let appName = options.appName;
+  let emberVersion = options.emberVersion;
+  let hasBowerComponents = options.hasBowerComponents;
 
-  promise = promise
+  let promise = Promise.resolve()
     .then(() => addEmberToBowerJSON(appName, emberVersion))
     .then(() => removeEmberDataFromBowerJSON(appName));
 
@@ -260,23 +267,28 @@ function addEmberDataToDependencies(appName, version) {
   fs.writeJsonSync('package.json', packageJSON);
 }
 
-function removeEmberSourceFromDependencies(appName, version) {
+function updateEmberSource(appName, version) {
   var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
-
   var packageJSON = fs.readJsonSync(packageJSONPath);
 
   // If we're not using bower, but the ember version is canary, we change it to
   // beta instead. This is because ember-source does not support canary releases.
   if (!usesBower && version === 'canary') {
+    debug('ember-source cannot use canary releases, defaulting to beta');
     version = 'beta';
   }
 
-  // If we're using canary, then it means we support bower, so we'll use ember
-  // from bower instead and drop ember-source.
-  if (version === 'canary' && packageJSON.devDependencies.hasOwnProperty('ember-source')) {
-    debug('removing ember-source from NPM ');
+  if (packageJSON.devDependencies.hasOwnProperty('ember-source')) {
+    // If we're using bower, we need to remove ember-source from package.json,
+    // otherwise we update to the appropriate version.
+    if (usesBower) {
+      debug('removing ember-source from NPM ');
+      delete packageJSON.devDependencies['ember-source'];
+    } else {
+      debug('updating ember-source version to %s', version);
+      packageJSON.devDependencies['ember-source'] = version;
+    }
 
-    delete packageJSON.devDependencies['ember-source'];
     fs.writeJsonSync('package.json', packageJSON);
   }
 }

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -1,32 +1,49 @@
 "use strict";
 
-var path  = require('path');
-var debug = require('./debug');
-var temp  = require('./temp');
-var chdir = require('./chdir');
-var fs = require('fs-extra');
-var findup = require('findup-sync');
-var existsSync       = fs.existsSync;
-var Promise = require('rsvp').Promise;
-var moveDirectory    = require('./move-directory');
-var symlinkDirectory = require('./symlink-directory');
-var runCommand       = require('./run-command');
-var runEmber         = require('./run-ember');
-var runNew           = require('./run-new');
-var mkdirp           = require('mkdirp');
+const path = require('path');
+const debug = require('./debug');
+const temp = require('./temp');
+const chdir = require('./chdir');
+const fs = require('fs-extra');
+const findup = require('findup-sync');
+const existsSync = fs.existsSync;
+const Promise = require('rsvp').Promise;
+const moveDirectory = require('./move-directory');
+const symlinkDirectory = require('./symlink-directory');
+const runCommand = require('./run-command');
+const runEmber = require('./run-ember');
+const runNew = require('./run-new');
+const mkdirp = require('mkdirp');
 
-var previousCwd;
+const runCommandOptions = {
+  // Note: We must override the default logOnFailure logging, because we are
+  // not inside a test.
+  log: function() {
+    return; // no output for initial application build
+  }
+};
 
-function cloneApp(appName, options) {
-  var tempDir = temp.ensureCreated();
+let previousCwd;
+
+/**
+ * Creates a new application with the given name. If the application was created
+ * previously, a fresh clone will be created.
+ *
+ * @param {String} appName
+ * @param {Object} [options]
+ * @param {String} [options.emberVersion]
+ * @param {String} [options.emberDataVersion]
+ */
+function createApp(appName, options) {
+  let tempDir = temp.ensureCreated();
+
   previousCwd = process.cwd();
-
   debug('previousCwd=%s', previousCwd);
 
   chdir(tempDir);
 
-  var pristineAppPath = path.join(temp.pristinePath, appName);
-  var underTestAppPath = path.join(temp.underTestPath, appName);
+  let pristineAppPath = path.join(temp.pristinePath, appName);
+  let underTestAppPath = path.join(temp.underTestPath, appName);
 
   // If this app was already tested, delete the copy.
   // This ensures that any modifications made during testing are
@@ -35,111 +52,115 @@ function cloneApp(appName, options) {
     fs.removeSync(underTestAppPath);
   }
 
-  // If a pristine version of the app doesn't exist, create it.
+  // If a pristine version of the app doesn't exist, create one by installing it.
+  let appInstallation;
   if (!fs.existsSync(pristineAppPath)) {
-    return installPristineApp(appName, options)
-      .then(function() {
-        copyUnderTestApp(pristineAppPath, underTestAppPath);
-      })
-      .then(function() {
-        chdir(previousCwd);
-        return underTestAppPath;
-      });
+    appInstallation = installPristineApp(appName, options);
+  } else {
+    appInstallation = Promise.resolve();
   }
 
-  copyUnderTestApp(pristineAppPath, underTestAppPath);
-  chdir(previousCwd);
-
-  return Promise.resolve(underTestAppPath);
+  return appInstallation.then(() => {
+    copyUnderTestApp(pristineAppPath, underTestAppPath);
+    chdir(previousCwd);
+    return underTestAppPath;
+  });
 }
 
 module.exports = {
-  cloneApp: cloneApp
+  createApp
 };
 
 function installPristineApp(appName, options) {
-  var hasNodeModules = hasPristineNodeModules();
-  var hasBowerComponents = hasPristineBowerComponents();
-  var extraOptions = [];
-  var emberVersion = options.emberVersion || 'canary';
-  var emberDataVersion = options.emberDataVersion || 'emberjs/data#master';
-
-  // First, determine if we can skip installing npm packages
-  // or Bower components if we have a pristine set of dependencies
-  // already.
-
-  // Fresh install
-  if (!hasNodeModules && !hasBowerComponents) {
-    debug("no node_modules or bower_components");
-  // bower_components but no node_modules
-  } else if (!hasNodeModules && hasBowerComponents) {
-    debug("no node_modules but existing bower_components");
-    extraOptions = ['--skip-bower'];
-  // node_modules but no bower_components
-  } else if (hasNodeModules && !hasBowerComponents) {
-    debug("no bower_components but existing node_modules");
-    extraOptions = ['--skip-npm'];
-  // Everything is already there
-  } else {
-    debug("existing node_modules and bower_components");
-    extraOptions = ['--skip-npm', '--skip-bower'];
-  }
+  let hasNodeModules = hasPristineNodeModules();
+  let hasBowerComponents = hasPristineBowerComponents();
 
   chdir(temp.pristinePath);
 
-  var args = extraOptions.concat(runCommandOptions);
-
-  var promise = runNew(appName, args)
+  // Install a vanilla app and cd into it
+  let args = generateArgsForEmberNew(hasNodeModules, hasBowerComponents);
+  let promise = runNew(appName, args)
     .catch(handleResult)
-    .then(function() {
-      chdir(path.join(temp.pristinePath, appName));
-    })
-    .then(addEmberDataToDependencies(appName, emberDataVersion))
-    .then(removeEmberSourceFromDependencies(appName, emberVersion));
+    .then(() => chdir(path.join(temp.pristinePath, appName)));
 
-  // If we installed a fresh node_modules or bower_components directory,
-  // grab those as pristine copies we can use in future runs.
+  let setupOptions = {
+    appName,
+    hasNodeModules,
+    hasBowerComponents,
+    emberVersion: options.emberVersion || 'canary',
+    emberDataVersion: options.emberDataVersion || 'emberjs/data#master'
+  };
+
+  promise = chainNodeModulesSetup(promise, setupOptions);
+  promise = chainBowerSetup(promise, setupOptions);
+
+  // All dependencies should be installed, so symlink them into the app and
+  // run the addon's blueprint to finish the app creation.
+  return promise
+    .then(() => linkDependencies(appName))
+    .then(runAddonGenerator);
+}
+
+// Generates the arguments to pass to `ember new`. Optionally skipping the
+// npm and/or bower installation phases.
+function generateArgsForEmberNew(skipNpm, skipBower) {
+  let extraOptions = [];
+
+  if (skipNpm) {
+    debug('skipping npm');
+    extraOptions.push('--skip-npm');
+  }
+
+  if (skipBower) {
+    debug('skipping bower');
+    extraOptions.push('--skip-bower');
+  }
+
+  return extraOptions.concat(runCommandOptions);
+}
+
+function chainNodeModulesSetup(promise, options) {
+  let { appName, emberDataVersion, emberVersion, hasNodeModules } = options;
+
+  // Modifies the package.json to include correct versions of dependencies
+  promise = promise
+    .then(() => addEmberDataToDependencies(appName, emberDataVersion))
+    .then(() => removeEmberSourceFromDependencies(appName, emberVersion));
+
+
   if (!hasNodeModules) {
-    promise = promise.then(function() {
+    promise = promise
+      .then(() => {
         debug('installing ember-disable-prototype-extensions');
         return runCommand('npm', 'install', 'ember-disable-prototype-extensions');
       })
-      .then(function() {
+      .then(() => {
         debug("installed ember-disable-prototype-extension");
-      })
-      .then(function() {
         return runCommand('npm', 'install');
       })
-      .then(function() {
-        debug('installed ember-data ' + emberDataVersion);
-      })
-      .then(symlinkAddon(appName));
+      .then(() => debug('installed ember-data ' + emberDataVersion))
+      .then(() => symlinkAddon(appName))
+      .then(() => movePristineNodeModules(appName));
   }
 
-  promise = promise.then(addEmberToBowerJSON(appName, emberVersion))
-                   .then(removeEmberDataFromBowerJSON(appName))
-                   .then(addAddonUnderTestToDependencies(appName));
+  return promise.then(() => addAddonUnderTestToDependencies(appName));
+}
+
+function chainBowerSetup(promise, options) {
+  let { appName, emberVersion, hasBowerComponents } = options;
+
+  promise = promise
+    .then(() => addEmberToBowerJSON(appName, emberVersion))
+    .then(() => removeEmberDataFromBowerJSON(appName));
 
   if (!hasBowerComponents) {
-    promise = promise.then(function() {
-      return runCommand('bower', 'install');
-    })
-    .then(function() {
-      debug('installed ember ' + emberVersion);
-    });
+    promise = promise
+      .then(() => runCommand('bower', 'install'))
+      .then(() => debug('installed ember ' + emberVersion))
+      .then(() => movePristineBowerComponents(appName));
   }
 
-  if (!hasNodeModules) {
-    promise = promise.then(movePristineNodeModules(appName));
-  }
-
-  if (!hasBowerComponents) {
-    promise = promise.then(movePristineBowerComponents(appName));
-  }
-
-  return promise.then(linkDependencies(appName))
-    // at this point we have all deps available, so we can run ember-cli
-    .then(runAddonGenerator);
+  return promise;
 }
 
 function hasPristineNodeModules() {
@@ -151,17 +172,13 @@ function hasPristineBowerComponents() {
 }
 
 function movePristineNodeModules(appName) {
-  return function() {
-    var nodeModulesPath = path.join(temp.pristinePath, appName, 'node_modules');
-    moveDirectory(nodeModulesPath, temp.pristineNodeModulesPath);
-  };
+  var nodeModulesPath = path.join(temp.pristinePath, appName, 'node_modules');
+  moveDirectory(nodeModulesPath, temp.pristineNodeModulesPath);
 }
 
 function movePristineBowerComponents(appName) {
-  return function() {
-    var bowerComponentsPath = path.join(temp.pristinePath, appName, 'bower_components');
-    moveDirectory(bowerComponentsPath, temp.pristineBowerComponentsPath);
-  };
+  var bowerComponentsPath = path.join(temp.pristinePath, appName, 'bower_components');
+  moveDirectory(bowerComponentsPath, temp.pristineBowerComponentsPath);
 }
 
 function handleResult(result) {
@@ -178,106 +195,94 @@ function copyUnderTestApp(pristineAppPath, underTestAppPath) {
 }
 
 function addEmberToBowerJSON(appName, version) {
-  return function() {
-    var bowerJSONPath = path.join(temp.pristinePath, appName, 'bower.json');
-    var bowerJSON = fs.readJsonSync(bowerJSONPath);
+  var bowerJSONPath = path.join(temp.pristinePath, appName, 'bower.json');
+  var bowerJSON = fs.readJsonSync(bowerJSONPath);
 
-    bowerJSON.resolutions = {
-      "ember": version
-    };
-
-    bowerJSON.dependencies['ember'] = version;
-
-    fs.writeJsonSync(bowerJSONPath, bowerJSON);
+  bowerJSON.resolutions = {
+    "ember": version
   };
+
+  bowerJSON.dependencies['ember'] = version;
+
+  fs.writeJsonSync(bowerJSONPath, bowerJSON);
 }
 
 function removeEmberDataFromBowerJSON(appName) {
-  return function() {
-    var bowerJSONPath = path.join(temp.pristinePath, appName, 'bower.json');
-    var bowerJSON = fs.readJsonSync(bowerJSONPath);
+  var bowerJSONPath = path.join(temp.pristinePath, appName, 'bower.json');
+  var bowerJSON = fs.readJsonSync(bowerJSONPath);
 
-    delete bowerJSON.dependencies['ember-data'];
+  delete bowerJSON.dependencies['ember-data'];
 
-    fs.writeJsonSync(bowerJSONPath, bowerJSON);
-  };
+  fs.writeJsonSync(bowerJSONPath, bowerJSON);
 }
 
 function symlinkAddon(appName) {
-  return function() {
-    var pkg = findAddonPackageJSON();
-    var addonPath = findAddonPath();
-    var addonSymlinkPath = path.join(temp.pristinePath, appName, 'node_modules', pkg.name);
-    var pkgScope = path.dirname(pkg.name);
+  var pkg = findAddonPackageJSON();
+  var addonPath = findAddonPath();
+  var addonSymlinkPath = path.join(temp.pristinePath, appName, 'node_modules', pkg.name);
+  var pkgScope = path.dirname(pkg.name);
 
-    debug("symlinking %s", pkg.name);
+  debug("symlinking %s", pkg.name);
 
-    if (pkgScope !== '.') {
-      debug("symlink: creating directory %s for scoped package name", pkgScope);
-      // In case the package has a scoped name, make sure the scope directoy exists before symlinking
-      mkdirp.sync(path.join(temp.pristinePath, appName, 'node_modules', pkgScope));
+  if (pkgScope !== '.') {
+    debug("symlink: creating directory %s for scoped package name", pkgScope);
+    // In case the package has a scoped name, make sure the scope directoy exists before symlinking
+    mkdirp.sync(path.join(temp.pristinePath, appName, 'node_modules', pkgScope));
+  }
+
+  if (existsSync(addonSymlinkPath)) {
+    var stats = fs.lstatSync(addonSymlinkPath);
+    if (stats.isSymbolicLink()) {
+      debug("%s is already symlinked", pkg.name);
+      return;
     }
 
-    if (existsSync(addonSymlinkPath)) {
-      var stats = fs.lstatSync(addonSymlinkPath);
-      if (stats.isSymbolicLink()) {
-        debug("%s is already symlinked", pkg.name);
-        return;
-      }
+    fs.removeSync(addonSymlinkPath);
+  }
 
-      fs.removeSync(addonSymlinkPath);
-    }
-
-    symlinkDirectory(addonPath, addonSymlinkPath);
-  };
+  symlinkDirectory(addonPath, addonSymlinkPath);
 }
 
 function addEmberDataToDependencies(appName, version) {
-  return function() {
-    var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
+  var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
 
-    debug('installing ember-data ' + version);
+  debug('installing ember-data ' + version);
 
-    var packageJSON = fs.readJsonSync(packageJSONPath);
+  var packageJSON = fs.readJsonSync(packageJSONPath);
 
-    packageJSON.devDependencies['ember-data'] = version;
+  packageJSON.devDependencies['ember-data'] = version;
 
-    fs.writeJsonSync('package.json', packageJSON);
-  };
+  fs.writeJsonSync('package.json', packageJSON);
 }
 
 function removeEmberSourceFromDependencies(appName, version) {
-  return function() {
-    var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
+  var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
 
-    var packageJSON = fs.readJsonSync(packageJSONPath);
+  var packageJSON = fs.readJsonSync(packageJSONPath);
 
-    if (version === 'canary' && packageJSON.devDependencies.hasOwnProperty('ember-source')) {
-      // ember-source does not support canary builds, therefore we will remove this entry and
-      // use ember from bower
-      debug('removing ember-source from NPM ');
+  if (version === 'canary' && packageJSON.devDependencies.hasOwnProperty('ember-source')) {
+    // ember-source does not support canary builds, therefore we will remove this entry and
+    // use ember from bower
+    debug('removing ember-source from NPM ');
 
-      delete packageJSON.devDependencies['ember-source'];
-      fs.writeJsonSync('package.json', packageJSON);
-    }
-  };
+    delete packageJSON.devDependencies['ember-source'];
+    fs.writeJsonSync('package.json', packageJSON);
+  }
 }
 
 function addAddonUnderTestToDependencies(appName) {
-  return function() {
-    var pkg = findAddonPackageJSON();
-    var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
+  var pkg = findAddonPackageJSON();
+  var packageJSONPath = path.join(temp.pristinePath, appName, 'package.json');
 
-    debug('installing %s as addon for application', pkg.name);
+  debug('installing %s as addon for application', pkg.name);
 
-    // Read the current version of the FastBoot addon under test, then add that
-    // to the Ember app's package.json.
-    var packageJSON = fs.readJsonSync(packageJSONPath);
+  // Read the current version of the FastBoot addon under test, then add that
+  // to the Ember app's package.json.
+  var packageJSON = fs.readJsonSync(packageJSONPath);
 
-    packageJSON.devDependencies[pkg.name] = pkg.version;
+  packageJSON.devDependencies[pkg.name] = pkg.version;
 
-    fs.writeJsonSync('package.json', packageJSON);
-  };
+  fs.writeJsonSync('package.json', packageJSON);
 }
 
 function runAddonGenerator() {
@@ -321,19 +326,9 @@ function findAddonPackageJSONPath() {
 }
 
 function linkDependencies(appName) {
-  return function() {
-    var nodeModulesAppPath = path.join(temp.pristinePath, appName, 'node_modules');
-    var bowerComponentsAppPath = path.join(temp.pristinePath, appName, 'bower_components');
+  var nodeModulesAppPath = path.join(temp.pristinePath, appName, 'node_modules');
+  var bowerComponentsAppPath = path.join(temp.pristinePath, appName, 'bower_components');
 
-    symlinkDirectory(temp.pristineNodeModulesPath, nodeModulesAppPath);
-    symlinkDirectory(temp.pristineBowerComponentsPath, bowerComponentsAppPath);
-  };
+  symlinkDirectory(temp.pristineNodeModulesPath, nodeModulesAppPath);
+  symlinkDirectory(temp.pristineBowerComponentsPath, bowerComponentsAppPath);
 }
-
-var runCommandOptions = {
-  // Note: We must override the default logOnFailure logging, because we are
-  // not inside a test.
-  log: function() {
-    return; // no output for initial application build
-  }
-};

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -14,7 +14,10 @@ const runCommand = require('./run-command');
 const runEmber = require('./run-ember');
 const runNew = require('./run-new');
 const mkdirp = require('mkdirp');
+const semver = require('semver');
 
+// As of Ember-CLI@2.13.0, it no longer uses Bower by default
+const usesBower = semver.lt(require('ember-cli/package').version, '2.13.0');
 const runCommandOptions = {
   // Note: We must override the default logOnFailure logging, because we are
   // not inside a test.
@@ -92,7 +95,10 @@ function installPristineApp(appName, options) {
   };
 
   promise = chainNodeModulesSetup(promise, setupOptions);
-  promise = chainBowerSetup(promise, setupOptions);
+
+  if (usesBower) {
+    promise = chainBowerSetup(promise, setupOptions);
+  }
 
   // All dependencies should be installed, so symlink them into the app and
   // run the addon's blueprint to finish the app creation.
@@ -126,7 +132,6 @@ function chainNodeModulesSetup(promise, options) {
   promise = promise
     .then(() => addEmberDataToDependencies(appName, emberDataVersion))
     .then(() => removeEmberSourceFromDependencies(appName, emberVersion));
-
 
   if (!hasNodeModules) {
     promise = promise
@@ -260,9 +265,15 @@ function removeEmberSourceFromDependencies(appName, version) {
 
   var packageJSON = fs.readJsonSync(packageJSONPath);
 
+  // If we're not using bower, but the ember version is canary, we change it to
+  // beta instead. This is because ember-source does not support canary releases.
+  if (!usesBower && version === 'canary') {
+    version = 'beta';
+  }
+
+  // If we're using canary, then it means we support bower, so we'll use ember
+  // from bower instead and drop ember-source.
   if (version === 'canary' && packageJSON.devDependencies.hasOwnProperty('ember-source')) {
-    // ember-source does not support canary builds, therefore we will remove this entry and
-    // use ember from bower
     debug('removing ember-source from NPM ');
 
     delete packageJSON.devDependencies['ember-source'];
@@ -326,9 +337,11 @@ function findAddonPackageJSONPath() {
 }
 
 function linkDependencies(appName) {
-  var nodeModulesAppPath = path.join(temp.pristinePath, appName, 'node_modules');
-  var bowerComponentsAppPath = path.join(temp.pristinePath, appName, 'bower_components');
-
+  let nodeModulesAppPath = path.join(temp.pristinePath, appName, 'node_modules');
   symlinkDirectory(temp.pristineNodeModulesPath, nodeModulesAppPath);
-  symlinkDirectory(temp.pristineBowerComponentsPath, bowerComponentsAppPath);
+
+  if (usesBower) {
+    let bowerComponentsAppPath = path.join(temp.pristinePath, appName, 'bower_components');
+    symlinkDirectory(temp.pristineBowerComponentsPath, bowerComponentsAppPath);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.1",
     "rsvp": "^3.1.0",
+    "semver": "^5.3.0",
     "symlink-or-copy": "^1.1.3",
     "temp": "^0.8.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "cross-env": "^4.0.0",
-    "ember-cli": "~2.12.0",
+    "ember-cli": "~2.13.0",
     "ember-cli-fastboot": "1.0.0-beta.18",
     "mocha": "^3.1.2",
     "mocha-eslint": "^3.0.1",


### PR DESCRIPTION
Fixes the most pressing use case of #75.

I refactored a good chunk of `pristine.js` to make it clearer what is going on (IMO). I merged logic branches when possible, broke up `installPristineApp` into chunks which have a specific meaning, removed all the return functions in favor of arrow functions, and renamed `cloneApp` to `createApp` (since cloning is an implementation detail of when you create an app the second time).

Edit: Verified this works in and fixes ember-engines tests.