### PR TITLE
tell people to first test the dummy app, before going down this path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@
 Test helpers for testing Ember CLI addons inside the context of a real
 Ember app.
 
-Previously, it was difficult to do real integration testing with Ember
-CLI addons because the process of creating a new Ember app is very slow, due
-to the required `npm install` and `bower install` steps.
+This help should only be used if testing the existing dummy app is not possible. In most cases
+testing the dummy app itself works well, is much faster, and also results in a dummy app with
+good examples.
+
+Scenarios where this addon is appropriate:
+
+* list 
+* of
+* scenarios
 
 This package automates the process of creating a new Ember CLI app and
 caching its npm and Bower dependencies, so each test run can get a fresh


### PR DESCRIPTION
cc @kellyselden / @rwjblue  can you provide some use-cases where this add-on is required, and testing the existing dummy app does not work?