### PR TITLE
fix server ready detection for ember-cli < 2.13

### DIFF
--- a/lib/commands/start-server.js
+++ b/lib/commands/start-server.js
@@ -50,7 +50,7 @@ module.exports = function runServer(options) {
 function detectServerStart(output) {
   var indicators = [
     'Ember FastBoot running at',
-    'Serving on'
+    'Build successful'
   ];
 
  for (var i = 0; i < indicators.length; i++) {


### PR DESCRIPTION
…by waiting until the build has completed

closes #118 