### PR TITLE
allow detectServerStart override

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,17 @@ app.startServer({
 });
 ```
 
+You can run your own command as well:
+
+```js
+app.startServer({
+  command: 'foo',
+  detectServerStart(output) {
+    return output.indexOf('foo is ready') > -1;
+  }
+});
+```
+
 ## Stopping the Server
 
 After your tests, stop the development server via `stopServer()`.

--- a/lib/commands/start-server.js
+++ b/lib/commands/start-server.js
@@ -12,7 +12,8 @@ module.exports = function runServer(options) {
 
     defaults(options, {
       port: '49741',
-      command: 'server'
+      command: 'server',
+      detectServerStart
     });
 
     let args = [
@@ -27,7 +28,7 @@ module.exports = function runServer(options) {
       verbose: true,
 
       onOutput: function(output, child) {
-        if (detectServerStart(output)) {
+        if (options.detectServerStart(output)) {
           resolve(child);
         }
       }

--- a/test/acceptance/complicated-test.js
+++ b/test/acceptance/complicated-test.js
@@ -34,7 +34,11 @@ describe('Acceptance | complicated', function() {
   });
 
   beforeEach(function() {
-    return app.startServer();
+    return app.startServer({
+      detectServerStart(output) {
+        return output.indexOf('Serving on ') > -1;
+      }
+    });
   });
 
   afterEach(function() {


### PR DESCRIPTION
This is useful if you are testing a custom command from your addon that doesn't have the standard "Build successful" output.