### PR TITLE
add skipNpm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ app.create('my-app', {
 
 The following options exist:
 
-| option           | description                                                                             | defaults to         |
-|------------------|-----------------------------------------------------------------------------------------|---------------------|
-| emberVersion     | Set the ember version the app should be created with, as you would in your `bower.json` | canary              |
-| emberDataVersion | Set the version of ember-data, as you would in your `package.json`                      | emberjs/data#master |
-| fixturesPath     | The path to look for your fixture files (see below)                                     | test/fixtures       |
-| noFixtures       | Disables the use of fixture files                                                       | false               |
+| option           | description                                                                                   | defaults to         |
+|------------------|-----------------------------------------------------------------------------------------------|---------------------|
+| emberVersion     | Set the ember version the app should be created with, as you would in your `bower.json`       | canary              |
+| emberDataVersion | Set the version of ember-data, as you would in your `package.json`                            | emberjs/data#master |
+| fixturesPath     | The path to look for your fixture files (see below)                                           | test/fixtures       |
+| noFixtures       | Disables the use of fixture files                                                             | false               |
+| skipNpm          | Useful if you want to edit the `package.json` and install later (skips the default blueprint) | false               |
 
 
 ### Fixtures

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -75,11 +75,16 @@ module.exports = {
 function installPristineApp(appName, options) {
   let hasNodeModules = hasPristineNodeModules();
   let hasBowerComponents = hasPristineBowerComponents();
+  let skipNpm = options.skipNpm;
 
   chdir(temp.pristinePath);
 
   // Install a vanilla app and cd into it
-  let args = generateArgsForEmberNew(hasNodeModules, hasBowerComponents);
+  let args = generateArgsForEmberNew(
+    hasNodeModules,
+    hasBowerComponents,
+    skipNpm
+  );
   let promise = runNew(appName, args)
     .catch(handleResult)
     .then(() => chdir(path.join(temp.pristinePath, appName)));
@@ -88,6 +93,7 @@ function installPristineApp(appName, options) {
     appName,
     hasNodeModules,
     hasBowerComponents,
+    skipNpm,
     emberVersion: options.emberVersion || 'canary',
     emberDataVersion: options.emberDataVersion || 'emberjs/data#master'
   };
@@ -109,15 +115,15 @@ function installPristineApp(appName, options) {
 
 // Generates the arguments to pass to `ember new`. Optionally skipping the
 // npm and/or bower installation phases.
-function generateArgsForEmberNew(skipNpm, skipBower) {
+function generateArgsForEmberNew(hasNodeModules, hasBowerComponents, skipNpm) {
   let extraOptions = [];
 
-  if (skipNpm) {
+  if (skipNpm || hasNodeModules) {
     debug('skipping npm');
     extraOptions.push('--skip-npm');
   }
 
-  if (skipBower) {
+  if (hasBowerComponents) {
     debug('skipping bower');
     extraOptions.push('--skip-bower');
   }
@@ -130,6 +136,7 @@ function nodeModulesSetup(options) {
   let emberVersion = options.emberVersion;
   let emberDataVersion = options.emberDataVersion;
   let hasNodeModules = options.hasNodeModules;
+  let skipNpm = options.skipNpm;
 
   // Modifies the package.json to include correct versions of dependencies
   let promise = Promise.resolve()
@@ -137,16 +144,19 @@ function nodeModulesSetup(options) {
     .then(() => updateEmberSource(appName, emberVersion));
 
   if (!hasNodeModules) {
+    if (!skipNpm) {
+      promise = promise
+        .then(() => {
+          debug('installing ember-disable-prototype-extensions');
+          return runCommand('npm', 'install', 'ember-disable-prototype-extensions');
+        })
+        .then(() => {
+          debug('installed ember-disable-prototype-extension');
+          return runCommand('npm', 'install');
+        })
+        .then(() => debug('installed ember-data ' + emberDataVersion));
+    }
     promise = promise
-      .then(() => {
-        debug('installing ember-disable-prototype-extensions');
-        return runCommand('npm', 'install', 'ember-disable-prototype-extensions');
-      })
-      .then(() => {
-        debug('installed ember-disable-prototype-extension');
-        return runCommand('npm', 'install');
-      })
-      .then(() => debug('installed ember-data ' + emberDataVersion))
       .then(() => symlinkAddon(appName))
       .then(() => movePristineNodeModules(appName));
   }
@@ -225,10 +235,15 @@ function removeEmberDataFromBowerJSON(appName) {
 }
 
 function symlinkAddon(appName) {
-  let pkg = findAddonPackageJSON();
-  let addonPath = findAddonPath();
-  let addonSymlinkPath = path.join(temp.pristinePath, appName, 'node_modules', pkg.name);
-  let pkgScope = path.dirname(pkg.name);
+  const pkg = findAddonPackageJSON();
+  const addonPath = findAddonPath();
+  const nodeModules = path.join(temp.pristinePath, appName, 'node_modules');
+
+  // if option skipNpm is supplied, node_modules doesn't exist yet
+  fs.ensureDirSync(nodeModules);
+
+  const addonSymlinkPath = path.join(nodeModules, pkg.name);
+  const pkgScope = path.dirname(pkg.name);
 
   debug('symlinking %s', pkg.name);
 

--- a/test/acceptance/complicated-test.js
+++ b/test/acceptance/complicated-test.js
@@ -18,7 +18,8 @@ describe('Acceptance | complicated', function() {
 
     return createAddon(() => {
       return app.create('dummy', {
-        fixturesPath: 'tests'
+        fixturesPath: 'tests',
+        skipNpm: true
       });
     }).then(() => {
       return copy(


### PR DESCRIPTION
avoid double `npm install` calls if you know you are going to manually manipulate package.json later.

cc @cibernox I know you will like this feature.