### PR TITLE
wait for exit before resolving stopServer

### DIFF
--- a/lib/commands/start-server.js
+++ b/lib/commands/start-server.js
@@ -23,12 +23,17 @@ module.exports = function runServer(options) {
       args = args.concat(options.additionalArguments);
     }
 
+    let longRunningServerPromise;
+
     let commandOptions = {
       verbose: true,
 
       onOutput(output, child) {
         if (options.detectServerStart(output)) {
-          resolve(child);
+          resolve({
+            server: child,
+            longRunningServerPromise
+          });
         }
       }
     };
@@ -37,7 +42,7 @@ module.exports = function runServer(options) {
 
     debug('starting server; command=%s; port=%s', options.command, options.port);
 
-    runEmber(options.command, args, temp.pristineNodeModulesPath)
+    longRunningServerPromise = runEmber(options.command, args, temp.pristineNodeModulesPath)
       .then(() => {
         throw new Error('The server should not have exited successfully.');
       })

--- a/lib/models/app.js
+++ b/lib/models/app.js
@@ -38,8 +38,9 @@ App.prototype.startServer = function(options) {
   process.chdir(this.path);
 
   return startServer(options)
-    .then(server => {
-      this.server = server;
+    .then(result => {
+      this.server = result.server;
+      this._longRunningServerPromise = result.longRunningServerPromise;
       process.chdir(previousCwd);
     });
 };
@@ -50,9 +51,10 @@ App.prototype.stopServer = function() {
   }
 
   killCliProcess(this.server);
-  this.server = null;
 
-  return Promise.resolve();
+  return this._longRunningServerPromise.catch(() => {
+    this.server = null;
+  });
 };
 
 module.exports = App;


### PR DESCRIPTION
This will fix #133.

What was happening in #133 is the time between the server killing and the next test cleaning up dirs got a lot shorter. Since the `stopServer` promise wasn't actually waiting for anything, we were getting file in use errors.