### PR TITLE
add pretty formatting to editPackageJSON

### DIFF
--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -35,7 +35,9 @@ AddonTestApp.prototype.editPackageJSON = function(cb) {
   let packageJSONPath = path.join(this.path, 'package.json');
   let pkg = fs.readJsonSync(packageJSONPath);
   cb(pkg);
-  fs.writeJsonSync(packageJSONPath, pkg);
+  fs.writeJsonSync(packageJSONPath, pkg, {
+    spaces: 2
+  });
 };
 
 module.exports = AddonTestApp;


### PR DESCRIPTION
This is useful when you are doing a deep folder comparison. It makes the package.json look like a real package.json.