### PR TITLE
use native EOL when saving package.json

### DIFF
--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -3,6 +3,7 @@
 const fs         = require('fs-extra');
 const path       = require('path');
 const util       = require('util');
+const EOL        = require('os').EOL;
 const App        = require('./app');
 const pristine   = require('../utilities/pristine');
 const copyFixtureFiles = require('../utilities/copy-fixture-files');
@@ -36,7 +37,8 @@ AddonTestApp.prototype.editPackageJSON = function(cb) {
   let pkg = fs.readJsonSync(packageJSONPath);
   cb(pkg);
   fs.writeJsonSync(packageJSONPath, pkg, {
-    spaces: 2
+    spaces: 2,
+    EOL
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "^3.0.0",
     "denodeify": "^1.2.1",
     "findup-sync": "^2.0.0",
-    "fs-extra": "^4.0.0",
+    "fs-extra": "^4.0.2",
     "lodash": "^4.0.0",
     "semver": "^5.3.0",
     "symlink-or-copy": "^1.1.3",


### PR DESCRIPTION
This will help https://github.com/kellyselden/ember-cli-update/pull/108 as there is a lot of cross-platform testing using fixture comparison going on.