### PR TITLE
Fix precooked dep support under npm5

### DIFF
--- a/lib/utilities/temp.js
+++ b/lib/utilities/temp.js
@@ -64,7 +64,7 @@ function ensureCreated() {
 // into the `pristine` directory before an app is created. That will be used rather than
 // having `ember new` do an `npm install`, saving significant time.
 function symlinkPrecookedNodeModules() {
-  let precookedNodeModulesPath = path.join(process.cwd(), 'tmp', 'precooked_node_modules');
+  let precookedNodeModulesPath = path.join(process.cwd(), 'tmp', 'precooked_node_modules', 'node_modules');
 
   // If the user running the tests has provided a "precooked" node_modules directory to be used
   // by an Ember app, we use that as the pristine version instead of running `npm install`. This

--- a/scripts/precook-node-modules.js
+++ b/scripts/precook-node-modules.js
@@ -22,7 +22,8 @@ fs.ensureDir('tmp')
     return runNew(appName);
   })
   .then(() => {
-    let precooked = path.join(root, 'tmp', 'precooked_node_modules');
+    let precooked = path.join(root, 'tmp', 'precooked_node_modules', 'node_modules');
+    fs.mkdirSync(path.dirname(precooked));
     moveDirectory(path.join(tmpDir, appName, 'node_modules'), precooked);
     symlinkDirectory(root, path.join(precooked, name));
   })


### PR DESCRIPTION
npm5 (and yarn) do module flattening. The current scheme used for precooked dependencies assumes that never happens.

This change adds a "node_modules" directory inside the tmp/precooked directory. That solves the problem by causing all of the top-level modules to be able to find each other.