### PR TITLE
don't hide errors in app.run()

### DIFF
--- a/lib/models/app.js
+++ b/lib/models/app.js
@@ -14,12 +14,14 @@ App.prototype.run = function() {
   let previousCwd = process.cwd();
   chdir(this.path);
 
-  function _finally() {
-    chdir(previousCwd);
-  }
-
   return runCommand.apply(null, arguments)
-    .then(_finally, _finally);
+    .then(function(result) {
+      chdir(previousCwd);
+      return result;
+    }, function(err) {
+      chdir(previousCwd);
+      throw err;
+    });
 };
 
 App.prototype.runEmberCommand = function() {


### PR DESCRIPTION
Fixes #163.

This may cause some people's test suites to fail. I think that's acceptable for a bugfix whose entire point is to stop silent errors from passing.