### PR TITLE
[WIP] Allowing link to be the absolute last step in the process

### DIFF
--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -32,6 +32,11 @@ AddonTestApp.prototype.create = function(appName, options) {
     .then(() => this);
 };
 
+AddonTestApp.prototype.link = function(appName) {
+  return pristine.link(appName)
+    .then(() => this);
+};
+
 AddonTestApp.prototype.editPackageJSON = function(cb) {
   let packageJSONPath = path.join(this.path, 'package.json');
   let pkg = fs.readJsonSync(packageJSONPath);

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -77,7 +77,8 @@ function link(appName) {
 }
 
 module.exports = {
-  createApp
+  createApp,
+  link
 };
 
 function installPristineApp(appName, options) {

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -63,9 +63,17 @@ function createApp(appName, options) {
 
   return appInstallation.then(() => {
     copyUnderTestApp(pristineAppPath, underTestAppPath);
+    return link(appName);
+  }).then(() => {
     chdir(previousCwd);
     return underTestAppPath;
   });
+}
+
+function link(appName) {
+  return Promise.resolve()
+    .then(() => linkDependencies(appName))
+    .then(runAddonGenerator);
 }
 
 module.exports = {
@@ -108,9 +116,7 @@ function installPristineApp(appName, options) {
 
   // All dependencies should be installed, so symlink them into the app and
   // run the addon's blueprint to finish the app creation.
-  return promise
-    .then(() => linkDependencies(appName))
-    .then(runAddonGenerator);
+  return promise;
 }
 
 // Generates the arguments to pass to `ember new`. Optionally skipping the


### PR DESCRIPTION
This is a work in progress PR that is supposed to spark a discussion around https://github.com/tomdale/ember-cli-addon-tests/issues/176. it is also related to https://github.com/kaliber5/ember-fastboot-addon-tests/issues/21

The idea is that we need to have the linking be the last step in the process after all times that `npm install` is called. As `ember-fastboot-addon-tests` does some npm magic of its own it would need to run the linking functionality again at a time that is suitable for that addon. I have a demo of what I was trying to achieve (will link the PR in a second)