### PR TITLE
Test against ember-data ^3.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "10"
 
 before_install:
-  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
-  - npm config set spin false
+  - if [[ `npm -v` != 6* ]]; then npm i -g npm@6; fi
   - npm install -g bower
   - bower --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
   - "10"
 
 before_install:
-  - if [[ `npm -v` != 6* ]]; then npm i -g npm@6; fi
+
+  # TODO: remove when we stop testing against node 6
+  - if [[ `npm -v` < 6* ]]; then npm i -g npm@6; fi
+
   - npm install -g bower
   - bower --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
   - nodejs_version: "10"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ init:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm i -g npm@^6
+  - npm i -g npm@^3
+  - npm config set spin false
   - npm install -g bower
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,7 @@ init:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm i -g npm@^3
-  - npm config set spin false
+  - npm i -g npm@^6
   - npm install -g bower
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,7 @@ init:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm i -g npm@^3
-  - npm config set spin false
+  - npm i -g npm@^6
   - npm install -g bower
   - npm install
 

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || '^3.6.0'
+    emberDataVersion: options.emberDataVersion || '^3.8.0'
   };
 
   promise = promise

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || 'emberjs/data#v3.8.0'
+    emberDataVersion: options.emberDataVersion || '^3.6.0'
   };
 
   promise = promise

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || 'emberjs/data#v3.8.0'
+    emberDataVersion: options.emberDataVersion || '~3.8.0'
   };
 
   promise = promise

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || 'emberjs/data#master'
+    emberDataVersion: options.emberDataVersion || 'emberjs/data#v3.8.0'
   };
 
   promise = promise

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -95,7 +95,7 @@ function installPristineApp(appName, options) {
     hasBowerComponents,
     skipNpm,
     emberVersion: options.emberVersion || 'canary',
-    emberDataVersion: options.emberDataVersion || '^3.8.0'
+    emberDataVersion: options.emberDataVersion || 'emberjs/data#v3.8.0'
   };
 
   promise = promise

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "chai": "^4.0.2",
     "cross-env": "^5.0.0",
-    "ember-cli": "~2.17.1",
+    "ember-cli": "~3.8.0",
     "ember-cli-fastboot": "^1.0.0",
     "eslint-config-sane": "^0.6.0",
     "eslint-plugin-prefer-let": "^1.0.1",


### PR DESCRIPTION
https://github.com/ember-fastboot/ember-cli-fastboot/pull/679

`ember-cli-addon-test` by default tests against `ember-data#master` this PR removes `#master` and uses `^3.8.0`

Updates ember-cli to `3.8.0`

https://github.com/ember-engines/ember-engines/pull/638