### PR TITLE
doc: ember serve does not support --production argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ You can also pass additional command line arguments via the
 `additionalArguments` option:
 
 ```js
-// equivalent to `ember serve --production`
+// equivalent to `ember serve -prod`
 app.startServer({
-  additionalArguments: ['--production']
+  additionalArguments: ['-prod']
 });
 ```
 


### PR DESCRIPTION
ember serve command does not have a `--production` argument. It has `-prod` as a shortcut for `--environment=production`.