### PR TITLE
bugfix with dirPath

### DIFF
--- a/lib/models/addon-test-app.js
+++ b/lib/models/addon-test-app.js
@@ -24,6 +24,9 @@ AddonTestApp.prototype.create = function(appName, options) {
 
   return pristine.createApp(appName, options)
     .then(appPath => {
+      if (!appPath) {
+        return Promise.reject('createApp failed');
+      }
       this.path = appPath;
       return options.noFixtures ?
         Promise.resolve() :

--- a/lib/utilities/pristine.js
+++ b/lib/utilities/pristine.js
@@ -12,10 +12,8 @@ const symlinkDirectory = require('./symlink-directory');
 const runCommand = require('./run-command');
 const runEmber = require('./run-ember');
 const runNew = require('./run-new');
-const semver = require('semver');
 
-// As of Ember-CLI@2.13.0, it no longer uses Bower by default
-const usesBower = semver.lt(require('ember-cli/package').version, '2.13.0');
+const usesBower = false;
 const runCommandOptions = {
   // Note: We must override the default logOnFailure logging, because we are
   // not inside a test.

--- a/lib/utilities/run-command.js
+++ b/lib/utilities/run-command.js
@@ -13,7 +13,7 @@ const exec           = denodeify(childProcess.exec);
 const isWindows = process.platform === 'win32';
 
 module.exports = function run(/* command, args, options */) {
-  let command = arguments[0];
+  let command = arguments[0] || 'node';
   let args = Array.prototype.slice.call(arguments, 1);
   let options = {};
 

--- a/lib/utilities/run-ember.js
+++ b/lib/utilities/run-ember.js
@@ -5,11 +5,13 @@ const findup = require('findup-sync');
 const runCommand = require('./run-command');
 
 module.exports = function(command, options, dirPath) {
-  let emberCLIPath = findup('node_modules/ember-cli', {
-    cwd: dirPath || __dirname
-  });
+  let cwd = __dirname;
+  if (dirPath && dirPath.startsWith(__dirname)) {
+    cwd = dirPath;
+  }
+  let emberCLIPath = findup('node_modules/ember-cli', { cwd });
 
-  let args = [path.join(emberCLIPath, 'bin', 'ember'), command].concat(options);
+  let args = ['node', path.join(emberCLIPath, 'bin', 'ember'), command].concat(options);
 
   return runCommand.apply(undefined, args);
 };


### PR DESCRIPTION
This is a fix for the error:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
```

I am getting in CI of ember-fetch. Tracing the error, `npm install` failed when creating a fresh app due to use of a `dirPath` outside the project.

It also cleans up the use of bower, since this project already doesn't work with bower and ember < 3 anyway.